### PR TITLE
fix: fix 3 line break before table tag to 2 line break

### DIFF
--- a/src/packages/presentation/document_convert_controller.py
+++ b/src/packages/presentation/document_convert_controller.py
@@ -25,9 +25,9 @@ class DocumentConvertController:
         for pdf in pathlib.Path(source_dir).glob('*.pdf'):
             with open(str(pdf), "rb") as file:
                 paragraphs = self.convert_service.extractDocument(file)
-                pathlib.Path(output_dir + '/' + pdf.name.split('.')[0] + ".md").write_bytes(paragraphs.encode())
+                pathlib.Path(output_dir + '/' + pdf.name.split('.')[0] + ".md").write_bytes(paragraphs.replace("\n\n\n<table>", "\n\n<table>").encode())
 
         for pdf in pathlib.Path(source_dir).glob('*.docx'):
             with open(str(pdf), "rb") as file:
                 paragraphs = self.convert_service.extractDocument(file)
-                pathlib.Path(output_dir + '/' + pdf.name.split('.')[0] + ".md").write_bytes(paragraphs.encode())
+                pathlib.Path(output_dir + '/' + pdf.name.split('.')[0] + ".md").write_bytes(paragraphs.replace("\n\n\n<table>", "\n\n<table>").encode())


### PR DESCRIPTION
`table`タグの前に3改行入ってしまうのを2改行にするように修正します